### PR TITLE
Add model filter functionality to chat and generate pages

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -101,8 +101,12 @@
                 <div class="card-body">
                     <h5 class="card-title">Model Selection</h5>
                     <div class="mb-3">
+                        <label for="model-filter" class="form-label">Filter models</label>
+                        <input type="text" class="form-control" id="model-filter" placeholder="Type to filter...">
+                    </div>
+                    <div class="mb-3">
                         <label for="model-select" class="form-label">Choose a model</label>
-                        <select class="form-select" id="model-select">
+                        <select class="form-select" id="model-select" size="5">
                             <option value="" disabled selected>Select a model</option>
                             {% for model in models %}
                             <option value="{{ model.name }}" {% if request.args.get('model') == model.name %}selected{% endif %}>{{ model.name }}</option>
@@ -142,13 +146,40 @@
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         const modelSelect = document.getElementById('model-select');
+        const modelFilter = document.getElementById('model-filter');
         const chatMessages = document.getElementById('chat-messages');
         const messageInput = document.getElementById('message-input');
         const sendButton = document.getElementById('send-button');
         const clearChatButton = document.getElementById('clear-chat');
-        
+
         let conversation = [];
         let isProcessing = false;
+
+        // Store all model options for filtering
+        const allModelOptions = Array.from(modelSelect.options).filter(opt => opt.value !== '');
+
+        // Model filter functionality
+        modelFilter.addEventListener('input', function() {
+            const filterText = this.value.toLowerCase();
+            const defaultOption = modelSelect.options[0];
+
+            // Clear all options except the default one
+            modelSelect.innerHTML = '';
+            modelSelect.add(defaultOption);
+
+            // Add filtered options
+            allModelOptions.forEach(option => {
+                if (option.textContent.toLowerCase().includes(filterText)) {
+                    modelSelect.add(option.cloneNode(true));
+                }
+            });
+
+            // If there's only one match (besides default), select it
+            if (modelSelect.options.length === 2 && filterText !== '') {
+                modelSelect.selectedIndex = 1;
+                modelSelect.dispatchEvent(new Event('change'));
+            }
+        });
         
         // Enable input when model is selected
         modelSelect.addEventListener('change', function() {

--- a/templates/generate.html
+++ b/templates/generate.html
@@ -248,10 +248,15 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Generation Options</h5>
-                    
+
+                    <div class="mb-3">
+                        <label for="model-filter" class="form-label">Filter models</label>
+                        <input type="text" class="form-control" id="model-filter" placeholder="Type to filter...">
+                    </div>
+
                     <div class="mb-3">
                         <label for="model-select" class="form-label">Model</label>
-                        <select class="form-select" id="model-select">
+                        <select class="form-select" id="model-select" size="5">
                             <option value="" disabled selected>Select a model</option>
                             {% for model in models %}
                             <option value="{{ model.name }}" {% if request.args.get('model') == model.name %}selected{% endif %}>{{ model.name }}</option>
@@ -429,12 +434,39 @@
     document.addEventListener('DOMContentLoaded', function() {
         // Main UI elements
         const modelSelect = document.getElementById('model-select');
+        const modelFilter = document.getElementById('model-filter');
         const promptInput = document.getElementById('prompt-input');
         const systemPrompt = document.getElementById('system-prompt');
         const generateButton = document.getElementById('generate-button');
         const resultContainer = document.getElementById('result-container');
         const resultLoading = document.getElementById('result-loading');
         const statsContainer = document.getElementById('stats-container');
+
+        // Store all model options for filtering
+        const allModelOptions = Array.from(modelSelect.options).filter(opt => opt.value !== '');
+
+        // Model filter functionality
+        modelFilter.addEventListener('input', function() {
+            const filterText = this.value.toLowerCase();
+            const defaultOption = modelSelect.options[0];
+
+            // Clear all options except the default one
+            modelSelect.innerHTML = '';
+            modelSelect.add(defaultOption);
+
+            // Add filtered options
+            allModelOptions.forEach(option => {
+                if (option.textContent.toLowerCase().includes(filterText)) {
+                    modelSelect.add(option.cloneNode(true));
+                }
+            });
+
+            // If there's only one match (besides default), select it
+            if (modelSelect.options.length === 2 && filterText !== '') {
+                modelSelect.selectedIndex = 1;
+                modelSelect.dispatchEvent(new Event('change'));
+            }
+        });
         
         // Parameter tuning elements
         const presetSelect = document.getElementById('preset-select');


### PR DESCRIPTION
## Summary

This PR adds a filter input field to the chat and generate pages, making it easier to find and select models from the dropdown list.

## Changes

- Add filter input field above model dropdown with real-time search
- Convert dropdown to listbox showing 5 models at once for better visibility
- Implement case-insensitive filtering that updates as you type
- Auto-select model when filter results in a single match
- Applied to both `/chat` and `/generate` pages for consistency

## Demo

Users can now:
1. Type any part of a model name to filter the list
2. See up to 5 models at once in the listbox
3. Have the model auto-selected when only one match is found

Fixes #1

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)